### PR TITLE
Fix crash, avoid code reduplication

### DIFF
--- a/CaseChange/CaseChange.glyphsPalette/Contents/Resources/plugin.py
+++ b/CaseChange/CaseChange.glyphsPalette/Contents/Resources/plugin.py
@@ -18,7 +18,6 @@ from vanilla import *
 class ChangeCase(PalettePlugin):
 
 	def settings(self):
-
 		self.name = "Change Case"
 
 		# Create Vanilla window and group with controls
@@ -26,40 +25,36 @@ class ChangeCase(PalettePlugin):
 		height = 90
 		self.paletteView = Window((width, height))
 		self.paletteView.group = Group((0, 0, width, height))
-		self.paletteView.group.UCButton = Button((10, -85, width-7, 20), "Uppercase", callback=self.upperCallback)
+		self.paletteView.group.UCButton = Button((10, -85, width-7, 20), "Uppercase", callback=self.changeCaseCallback)
 		self.paletteView.group.UCButton.getNSButton().setToolTip_(u"ABC Abc abc → ABC ABC ABC")
-		self.paletteView.group.lcButton = Button((10, -60, width-7, 20), "Lowercase", callback=self.lowerCallback)
+		self.paletteView.group.lcButton = Button((10, -60, width-7, 20), "Lowercase", callback=self.changeCaseCallback)
 		self.paletteView.group.lcButton.getNSButton().setToolTip_(u"ABC Abc abc → abc abc abc")
-		self.paletteView.group.titleButton = Button((10, -35, width-7, 20), "Title", callback=self.titleCallback)
+		self.paletteView.group.titleButton = Button((10, -35, width-7, 20), "Title", callback=self.changeCaseCallback)
 		self.paletteView.group.titleButton.getNSButton().setToolTip_(u"ABC Abc abc → Abc Abc Abc")
 		
 		# Set dialog to NSView
 		self.dialog = self.paletteView.group.getNSView()
-
-			
-	# Uppercase
-	def upperCallback(self, sender):
-		windowController = self.windowController()
-		if windowController:
-			thisFont = windowController.document().font
-			if thisFont.currentTab.text:
-				thisFont.currentTab.text = thisFont.currentTab.text.upper()
-		
-	# Lowercase
-	def lowerCallback(self, sender):
-		windowController = self.windowController()
-		if windowController:
-			thisFont = windowController.document().font
-			if thisFont.currentTab.text:
-				thisFont.currentTab.text = thisFont.currentTab.text.lower()
 	
-	# Title
-	def titleCallback(self, sender):
+	def changeCaseCallback(self, sender):
 		windowController = self.windowController()
+		
 		if windowController:
 			thisFont = windowController.document().font
-			if thisFont.currentTab.text:
-				thisFont.currentTab.text = thisFont.currentTab.text.title()
-
-
-
+			currentTab = thisFont.currentTab
+			
+			# check if there is a tab open that contains text:
+			if currentTab and currentTab.text:
+				
+				# query current text in tab:
+				tabText = currentTab.text
+				
+				# change case depending on which button was pressed:
+				if sender == self.paletteView.group.UCButton:
+					tabText = tabText.upper()
+				elif sender == self.paletteView.group.lcButton:
+					tabText = tabText.lower()
+				elif sender == self.paletteView.group.titleButton:
+					tabText = tabText.title()
+					
+				# replace text in tab:
+				thisFont.currentTab.text = tabText


### PR DESCRIPTION
Fix for crash:

```text
Details:
Traceback (most recent call last):

  File "~/Library/Application Support/Glyphs/Scripts/vanilla/vanillaBase.py", line 500, in action_
    self.callback(sender)

  File "~/Library/Application Support/Glyphs/Repositories/Change Case/CaseChange/CaseChange.glyphsPalette/Contents/Resources/plugin.py", line 53, in lowerCallback
    if thisFont.currentTab.text:

AttributeError: 'NoneType' object has no attribute 'text'
```